### PR TITLE
Add initial Dockerfile for creating image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:stable
+
+MAINTAINER Clifton Barnes <clifton.a.barnes@gmail.com>
+
+RUN apt-get update
+RUN apt-get install -y python python-dev python-pip lighttpd
+RUN pip install flask flask_cors
+
+EXPOSE 80 5000
+
+ADD www /var/www/html/
+
+WORKDIR /var/www/html
+RUN echo '/etc/init.d/lighttpd start && python /var/www/html/app.py' > /usr/bin/run.sh
+ENTRYPOINT ["bash", "/usr/bin/run.sh"]


### PR DESCRIPTION
This will create a docker image with python and lighttpd. It doesn't include php since that is going away. The `Dockerfile` needs to be in this directory because it does not support having relative paths with `..`. I've connected Docker Hub to the repository to automatically generate images on changes. The image will be in my [repository](https://hub.docker.com/r/cabarnes/rovercode/) on Docker Hub. I'm planning to have a `latest` tag that will be the build from the `development` branch and a `stable` tag that will be the build from the `master` branch.

This addresses issue #30 