### PR TITLE
Removes domain and port for rover service resources

### DIFF
--- a/www/app.py
+++ b/www/app.py
@@ -1,12 +1,10 @@
 from flask import Flask, jsonify, Response, request
 from os import listdir
 from os.path import isfile, join
-from flask_cors import CORS, cross_origin
 import xml.etree.ElementTree
 import Adafruit_GPIO.PWM as pwmLib
 
 app = Flask(__name__)
-CORS(app)
 
 pwm = pwmLib.get_platform_pwm(pwmtype="softpwm")
 

--- a/www/js/blockly-api.js
+++ b/www/js/blockly-api.js
@@ -93,19 +93,6 @@ function initApi(interpreter, scope) {
 		interpreter.createNativeFunction(wrapper));
 }
 
-/*-----HELPER FUNCTIONS -----*/
-
-function sendMotorCommand(command, pin, speed) {
-	$.post(roverResource('sendcommand'),
-		{
-			command: command,
-			pin: pin,
-			speed: Number(speed)
-		}, function (response) {
-			//writeToConsole(response);
-		});
-}
-
 // function checkSensor(sensor) {
 // 	sensorVal = 0;
 //   if (sensor == 'SENSORS_left') {

--- a/www/js/blockly-api.js
+++ b/www/js/blockly-api.js
@@ -96,7 +96,7 @@ function initApi(interpreter, scope) {
 /*-----HELPER FUNCTIONS -----*/
 
 function sendMotorCommand(command, pin, speed) {
-	$.post('http://localhost:5000/api/v1/sendcommand',
+	$.post(roverResource('sendcommand'),
 		{
 			command: command,
 			pin: pin,

--- a/www/js/mission-control.js
+++ b/www/js/mission-control.js
@@ -10,9 +10,6 @@ var blocklyArea = document.getElementById('blocklyArea');
 var blocklyDiv = document.getElementById('blocklyDiv');
 var eventQueue = [];
 
-var roverDomain = ''; //Later, if the rover is not hosting the webpage, its address will go here
-var roverApiPath = '/api/v1/';
-
 /*----- SENSOR VALUES CACHE -----*/
 /** Keep track of the last-known value of a sensor locally. Update
 	* it according to events. This keeps us from having to do a synchronous
@@ -157,84 +154,6 @@ function updateLocalStateAfterEvent(event){
 function chooseDesign() {
 	$('#loadModal').foundation('reveal', 'open');
 	refreshSavedBds();
-}
-
-function saveDesign() {
-	xml = Blockly.Xml.workspaceToDom(workspace);
-	xmlString = Blockly.Xml.domToText(xml);
-	$.post(roverResource('blockdiagrams'), {bdString: xmlString, designName: designName}, function(response){
-	}).error(function(){
-			writeToConsole("There was an error saving your design to the rover");
-	});
-}
-
-function refreshSavedBds() {
-	$.get(roverResource('blockdiagrams'), function(json){
-		if (!json.result.length){
-			$('#savedDesignsArea').text("There are no designs saved on this rover");
-		} else {
-			$('#savedDesignsArea').empty();
-			json.result.forEach(function(entry) {
-				$('#savedDesignsArea').append("<a href='#' class='button' style='margin:10px;' onclick='return loadDesign(\""+entry+"\")'>"+entry+"</a>");
-			});
-		}
-	}
-	);
-}
-
-function loadDesign(name) {
-	$('#loadModal').foundation('reveal', 'close');
-	$.get(roverResource('blockdiagrams')+'/'+name, function(response){
-		workspace.clear();
-
-		xmlDom = Blockly.Xml.textToDom(response.getElementsByTagName('bd')[0].childNodes[0].nodeValue);
-		Blockly.Xml.domToWorkspace(workspace, xmlDom);
-		if (name == 'event_handler_hidden')
-			designName = "Unnamed_Design_" + (Math.floor(Math.random()*1000)).toString();
-		else
-			designName = name;
-		$('a#downloadLink').attr("href", "saved-bds/"+designName+".xml");
-		$('a#downloadLink').attr("download", designName+".xml");
-		$('a#designNameArea').text(designName);
-
-		hideBlockByComment("MAIN EVENT HANDLER LOOP");
-		var hiddenBlock;
-		var allBlocksHidden = true;
-		for (hiddenBlock of blocksToHide) {
-			if (!hideBlock(hiddenBlock))
-				allBlocksHidden = false;
-		}
-		if (allBlocksHidden)
-			showBlock('always');
-	}).error(function(){
-			alert("There was an error loading your design from the rover");
-	});
-	updateCode();
-}
-
-function acceptName() {
-	designName = $('input[name=designName]').val();
-
-	$.get(roverResource('blockdiagrams'), function(json){
-		var duplicate = false;
-		for (var i=0; i<json.length; i++){
-			if (json[i] == designName)
-				duplicate = true;
-		}
-
-		if (designName === ''){
-			$('#nameErrorArea').text('Please enter a name for your design in the box');
-		} else if (duplicate) {
-			$('#nameErrorArea').text('This name has already been chosen. Please pick another one.');
-		} else {
-			saveDesign();
-			$('#nameErrorArea').empty();
-			$('a#designNameArea').text(designName);
-			$('a#downloadLink').attr("href", "saved-bds/"+designName+".xml");
-			$('a#downloadLink').attr("download", designName+".xml");
-			$('#nameModal').foundation('reveal', 'close');
-		}
-	});
 }
 
 $('#uploadForm #fileToUpload').change(function(){

--- a/www/js/mission-control.js
+++ b/www/js/mission-control.js
@@ -10,6 +10,9 @@ var blocklyArea = document.getElementById('blocklyArea');
 var blocklyDiv = document.getElementById('blocklyDiv');
 var eventQueue = [];
 
+var roverDomain = ''; //Later, if the rover is not hosting the webpage, its address will go here
+var roverApiPath = '/api/v1/';
+
 /*----- SENSOR VALUES CACHE -----*/
 /** Keep track of the last-known value of a sensor locally. Update
 	* it according to events. This keeps us from having to do a synchronous
@@ -18,6 +21,11 @@ var eventQueue = [];
 var sensorStateCache = new Array();
 sensorStateCache["SENSORS_leftIr"] = false;
 sensorStateCache["SENSORS_rightIr"] = false;
+
+/*----- HELPER FUNCTIONS -----*/
+function roverResource(resource) {
+	return roverDomain+roverApiPath+resource;
+}
 
 /*----- INIT CODE -----*/
 /* Set overall Blockly colors */
@@ -159,14 +167,14 @@ function chooseDesign() {
 function saveDesign() {
 	xml = Blockly.Xml.workspaceToDom(workspace);
 	xmlString = Blockly.Xml.domToText(xml);
-	$.post('http://localhost:5000/api/v1/blockdiagrams', {bdString: xmlString, designName: designName}, function(response){
+	$.post(roverResource('blockdiagrams'), {bdString: xmlString, designName: designName}, function(response){
 	}).error(function(){
 			writeToConsole("There was an error saving your design to the rover");
 	});
 }
 
 function refreshSavedBds() {
-	$.get('http://localhost:5000/api/v1/blockdiagrams', function(json){
+	$.get(roverResource('blockdiagrams'), function(json){
 		if (!json.result.length){
 			$('#savedDesignsArea').text("There are no designs saved on this rover");
 		} else {
@@ -181,7 +189,7 @@ function refreshSavedBds() {
 
 function loadDesign(name) {
 	$('#loadModal').foundation('reveal', 'close');
-	$.get('http://localhost:5000/api/v1/blockdiagrams/'+name, function(response){
+	$.get(roverResource('blockdiagrams')+'/'+name, function(response){
 		workspace.clear();
 
 		xmlDom = Blockly.Xml.textToDom(response.getElementsByTagName('bd')[0].childNodes[0].nodeValue);
@@ -212,7 +220,7 @@ function loadDesign(name) {
 function acceptName() {
 	designName = $('input[name=designName]').val();
 
-	$.get('http://localhost:5000/api/v1/blockdiagrams', function(json){
+	$.get(roverResource('blockdiagrams'), function(json){
 		var duplicate = false;
 		for (var i=0; i<json.length; i++){
 			if (json[i] == designName)

--- a/www/js/mission-control.js
+++ b/www/js/mission-control.js
@@ -22,11 +22,6 @@ var sensorStateCache = new Array();
 sensorStateCache["SENSORS_leftIr"] = false;
 sensorStateCache["SENSORS_rightIr"] = false;
 
-/*----- HELPER FUNCTIONS -----*/
-function roverResource(resource) {
-	return roverDomain+roverApiPath+resource;
-}
-
 /*----- INIT CODE -----*/
 /* Set overall Blockly colors */
 Blockly.HSV_SATURATION = 0.85;

--- a/www/js/rover-api.js
+++ b/www/js/rover-api.js
@@ -1,3 +1,7 @@
+/*----- MISC GLOBALS -----*/
+var roverDomain = ''; //Later, if the rover is not hosting the webpage, its address will go here
+var roverApiPath = '/api/v1/';
+
 /*----- HELPER FUNCTIONS -----*/
 function roverResource(resource) {
 	return roverDomain+roverApiPath+resource;

--- a/www/js/rover-api.js
+++ b/www/js/rover-api.js
@@ -71,8 +71,9 @@ function loadDesign(name) {
 			if (!hideBlock(hiddenBlock))
 				allBlocksHidden = false;
 		}
-		if (allBlocksHidden)
+		if (allBlocksHidden) {
 			showBlock('always');
+		}
 	}).error(function(){
 			alert("There was an error loading your design from the rover");
 	});
@@ -82,24 +83,22 @@ function loadDesign(name) {
 function acceptName() {
 	designName = $('input[name=designName]').val();
 
-	$.get(roverResource('blockdiagrams'), function(json){
-		var duplicate = false;
-		for (var i=0; i<json.length; i++){
-			if (json[i] == designName)
-				duplicate = true;
-		}
+	if (!designName) {
+		$('#nameErrorArea').text('Please enter a name for your design in the box');
+	} else {
+		$.get(roverResource('blockdiagrams'), function(json){
+			var duplicate = json.result.indexOf(designName) > -1;
+			if (duplicate) {
+				$('#nameErrorArea').text('This name has already been chosen. Please pick another one.');
+			} else {
+				saveDesign();
+				$('#nameErrorArea').empty();
+				$('a#designNameArea').text(designName);
+				$('a#downloadLink').attr("href", "saved-bds/"+designName+".xml");
+				$('a#downloadLink').attr("download", designName+".xml");
+				$('#nameModal').foundation('reveal', 'close');
+			}
+		});
+	}
 
-		if (designName === ''){
-			$('#nameErrorArea').text('Please enter a name for your design in the box');
-		} else if (duplicate) {
-			$('#nameErrorArea').text('This name has already been chosen. Please pick another one.');
-		} else {
-			saveDesign();
-			$('#nameErrorArea').empty();
-			$('a#designNameArea').text(designName);
-			$('a#downloadLink').attr("href", "saved-bds/"+designName+".xml");
-			$('a#downloadLink').attr("download", designName+".xml");
-			$('#nameModal').foundation('reveal', 'close');
-		}
-	});
 }

--- a/www/js/rover-api.js
+++ b/www/js/rover-api.js
@@ -44,7 +44,7 @@ function refreshSavedBds() {
 
 function loadDesign(name) {
 	$('#loadModal').foundation('reveal', 'close');
-	$.get(roverResource(['blockdiagrams', 'name']), function(response){
+	$.get(roverResource(['blockdiagrams', name]), function(response){
 		workspace.clear();
 
 		xmlDom = Blockly.Xml.textToDom(response.getElementsByTagName('bd')[0].childNodes[0].nodeValue);

--- a/www/js/rover-api.js
+++ b/www/js/rover-api.js
@@ -1,0 +1,94 @@
+/*----- HELPER FUNCTIONS -----*/
+function roverResource(resource) {
+	return roverDomain+roverApiPath+resource;
+}
+
+/*----- ROVER API FUNCTIONS -----*/
+function sendMotorCommand(command, pin, speed) {
+	$.post(roverResource('sendcommand'),
+		{
+			command: command,
+			pin: pin,
+			speed: Number(speed)
+		}, function (response) {
+			//writeToConsole(response);
+		});
+}
+
+function saveDesign() {
+	xml = Blockly.Xml.workspaceToDom(workspace);
+	xmlString = Blockly.Xml.domToText(xml);
+	$.post(roverResource('blockdiagrams'), {bdString: xmlString, designName: designName}, function(response){
+	}).error(function(){
+			writeToConsole("There was an error saving your design to the rover");
+	});
+}
+
+function refreshSavedBds() {
+	$.get(roverResource('blockdiagrams'), function(json){
+		if (!json.result.length){
+			$('#savedDesignsArea').text("There are no designs saved on this rover");
+		} else {
+			$('#savedDesignsArea').empty();
+			json.result.forEach(function(entry) {
+				$('#savedDesignsArea').append("<a href='#' class='button' style='margin:10px;' onclick='return loadDesign(\""+entry+"\")'>"+entry+"</a>");
+			});
+		}
+	}
+	);
+}
+
+function loadDesign(name) {
+	$('#loadModal').foundation('reveal', 'close');
+	$.get(roverResource('blockdiagrams')+'/'+name, function(response){
+		workspace.clear();
+
+		xmlDom = Blockly.Xml.textToDom(response.getElementsByTagName('bd')[0].childNodes[0].nodeValue);
+		Blockly.Xml.domToWorkspace(workspace, xmlDom);
+		if (name == 'event_handler_hidden')
+			designName = "Unnamed_Design_" + (Math.floor(Math.random()*1000)).toString();
+		else
+			designName = name;
+		$('a#downloadLink').attr("href", "saved-bds/"+designName+".xml");
+		$('a#downloadLink').attr("download", designName+".xml");
+		$('a#designNameArea').text(designName);
+
+		hideBlockByComment("MAIN EVENT HANDLER LOOP");
+		var hiddenBlock;
+		var allBlocksHidden = true;
+		for (hiddenBlock of blocksToHide) {
+			if (!hideBlock(hiddenBlock))
+				allBlocksHidden = false;
+		}
+		if (allBlocksHidden)
+			showBlock('always');
+	}).error(function(){
+			alert("There was an error loading your design from the rover");
+	});
+	updateCode();
+}
+
+function acceptName() {
+	designName = $('input[name=designName]').val();
+
+	$.get(roverResource('blockdiagrams'), function(json){
+		var duplicate = false;
+		for (var i=0; i<json.length; i++){
+			if (json[i] == designName)
+				duplicate = true;
+		}
+
+		if (designName === ''){
+			$('#nameErrorArea').text('Please enter a name for your design in the box');
+		} else if (duplicate) {
+			$('#nameErrorArea').text('This name has already been chosen. Please pick another one.');
+		} else {
+			saveDesign();
+			$('#nameErrorArea').empty();
+			$('a#designNameArea').text(designName);
+			$('a#downloadLink').attr("href", "saved-bds/"+designName+".xml");
+			$('a#downloadLink').attr("download", designName+".xml");
+			$('#nameModal').foundation('reveal', 'close');
+		}
+	});
+}

--- a/www/js/rover-api.js
+++ b/www/js/rover-api.js
@@ -35,7 +35,14 @@ function refreshSavedBds() {
 		} else {
 			$('#savedDesignsArea').empty();
 			json.result.forEach(function(entry) {
-				$('#savedDesignsArea').append("<a href='#' class='button' style='margin:10px;' onclick='return loadDesign(\""+entry+"\")'>"+entry+"</a>");
+				$(document.createElement('a')).addClass('button')
+					.html(entry)
+					.attr('href', '#')
+					.css('margin', '10px')
+					.appendTo($("#savedDesignsArea"))
+					.click(function() {
+						return loadDesign(entry);
+					});
 			});
 		}
 	}

--- a/www/js/rover-api.js
+++ b/www/js/rover-api.js
@@ -4,7 +4,7 @@ var roverApiPath = '/api/v1/';
 
 /*----- HELPER FUNCTIONS -----*/
 function roverResource(resource) {
-	return roverDomain+roverApiPath+resource;
+	return roverDomain + roverApiPath + (Array.isArray(resource) ? resource.join('/') : resource);
 }
 
 /*----- ROVER API FUNCTIONS -----*/
@@ -44,7 +44,7 @@ function refreshSavedBds() {
 
 function loadDesign(name) {
 	$('#loadModal').foundation('reveal', 'close');
-	$.get(roverResource('blockdiagrams')+'/'+name, function(response){
+	$.get(roverResource(['blockdiagrams', 'name']), function(response){
 		workspace.clear();
 
 		xmlDom = Blockly.Xml.textToDom(response.getElementsByTagName('bd')[0].childNodes[0].nodeValue);

--- a/www/js/rover-utilities.js
+++ b/www/js/rover-utilities.js
@@ -1,0 +1,4 @@
+/*----- HELPER FUNCTIONS -----*/
+function roverResource(resource) {
+	return roverDomain+roverApiPath+resource;
+}

--- a/www/js/rover-utilities.js
+++ b/www/js/rover-utilities.js
@@ -1,4 +1,0 @@
-/*----- HELPER FUNCTIONS -----*/
-function roverResource(resource) {
-	return roverDomain+roverApiPath+resource;
-}

--- a/www/mission-control.html
+++ b/www/mission-control.html
@@ -50,6 +50,7 @@
 	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
 	<link href="https://fonts.googleapis.com/css?family=Faster+One" rel="stylesheet">
 	<link rel="stylesheet" href="foundation-icons/foundation-icons.css">
+	<script src="js/rover-utilities.js"></script>
 	<script src="js/blockly-api.js"></script>
 
 </head>

--- a/www/mission-control.html
+++ b/www/mission-control.html
@@ -50,7 +50,7 @@
 	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
 	<link href="https://fonts.googleapis.com/css?family=Faster+One" rel="stylesheet">
 	<link rel="stylesheet" href="foundation-icons/foundation-icons.css">
-	<script src="js/rover-utilities.js"></script>
+	<script src="js/rover-api.js"></script>
 	<script src="js/blockly-api.js"></script>
 
 </head>


### PR DESCRIPTION
Using "localhost:5000" to access the Flask service works great on development PCs, but doesn't work in the final use-case of running a browser on one PC and the Flask service on the rover.

This pull request removes the localhost domain in the url and creates a variable for the rover's IP address. 

For now, we'll assume that the Flask service and the webpage are being hosted from the same place, and set the IP address to an empty string.  Since browsers don't like to let you access other ports than the one that served you the webpage, we'll need to access the Flask API through Lighttpd's port 80. To set up lightly to forward our API calls on to Flask's port 5000, follow these steps:

* Edit your lighttpd.conf in these two ways
  * Uncomment the line that says "mod_proxy" to enable mod_proxy
  * Add this somewhere:
   ```
#### proxy module
## read proxy.txt for more info
proxy.server               = ( "/api/v1/" =>
                               (
                                 (
                                   "host" => "127.0.0.1",
                                   "port" => 5000
                                 )
                               )
                             )
   ```

* Restart lighttpd
`sudo /etc/init.d/lighttpd restart`