### PR TITLE
Fix missing setting in lighttpd.conf

### DIFF
--- a/www/lighttpd.conf
+++ b/www/lighttpd.conf
@@ -15,6 +15,7 @@ server.username             = "www-data"
 server.groupname            = "www-data"
 server.port                 = 80
 
+index-file.names            = ( "index.php", "index.html", "index.lighttpd.html" )
 url.access-deny = ( "~", ".inc" )
 static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
 


### PR DESCRIPTION
I know that we'll be moving on from lighttpd here soon. But, the web interface was completely broken without this line in my Docker image. Not sure how it seemed like it worked before.