### PR TITLE
Add testing and coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+include = www/*
+omit = *tests*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ before_install:
   - sudo apt-get install -qq graphviz-dev python-setuptools python3-dev python-virtualenv python-pip
   - sudo apt-get install -qq firefox automake libtool libreadline6 libreadline6-dev libreadline-dev
   - sudo apt-get install -qq libsqlite3-dev libxml2 libxml2-dev libssl-dev libbz2-dev wget curl llvm
+  - git clone https://github.com/aninternetof/Adafruit_Python_GPIO.git
+  - cd Adafruit_Python_GPIO
+  - python setup.py install
+  - cd ../
 install:
   - pip install flask flask-socketio gevent uwsgi Sphinx==1.4.8 sphinx_rtd_theme pytest-flask pytest-cov mock
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - sudo apt-get install -qq firefox automake libtool libreadline6 libreadline6-dev libreadline-dev
   - sudo apt-get install -qq libsqlite3-dev libxml2 libxml2-dev libssl-dev libbz2-dev wget curl llvm
 install:
-  - pip install flask flask-socketio gevent uwsgi Sphinx==1.4.8 sphinx_rtd_theme pytest-flask pytest-cov mockflask flask-socketio gevent uwsgi Sphinx==1.4.8 sphinx_rtd_theme pytest-flask pytest-cov mock
+  - pip install flask flask-socketio gevent uwsgi Sphinx==1.4.8 sphinx_rtd_theme pytest-flask pytest-cov mock
   - pip install coveralls
 script:
   - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: true
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq build-essential gettext python-dev zlib1g-dev libpq-dev xvfb
+  - sudo apt-get install -qq libtiff4-dev libjpeg8-dev libfreetype6-dev liblcms1-dev libwebp-dev
+  - sudo apt-get install -qq graphviz-dev python-setuptools python3-dev python-virtualenv python-pip
+  - sudo apt-get install -qq firefox automake libtool libreadline6 libreadline6-dev libreadline-dev
+  - sudo apt-get install -qq libsqlite3-dev libxml2 libxml2-dev libssl-dev libbz2-dev wget curl llvm
+install:
+  - pip install flask flask-socketio gevent uwsgi Sphinx==1.4.8 sphinx_rtd_theme pytest-flask pytest-cov mockflask flask-socketio gevent uwsgi Sphinx==1.4.8 sphinx_rtd_theme pytest-flask pytest-cov mock
+  - pip install coveralls
+script:
+  - py.test
+after_success:
+  - coveralls
+language: python
+python:
+- "2.7"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Clifton Barnes <clifton.a.barnes@gmail.com>
 
 RUN apt-get update
 RUN apt-get install -y python python-dev python-pip python-smbus nginx build-essential git libssl-dev
-RUN pip install flask flask-socketio gevent uwsgi Sphinx==1.4.8 sphinx_rtd_theme
+RUN pip install flask flask-socketio gevent uwsgi Sphinx==1.4.8 sphinx_rtd_theme pytest-flask pytest-cov mock
 
 EXPOSE 80
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Gitter](https://badges.gitter.im/aninternetof/rovercode.svg)](https://gitter.im/aninternetof/rovercode?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![MailingList](https://img.shields.io/badge/join-mailing%20list-yellow.svg?style=flat)](http://rovercode.org/cgi-bin/mailman/listinfo/developers)
 [![](https://images.microbadger.com/badges/image/cabarnes/rovercode.svg)](https://microbadger.com/images/cabarnes/rovercode)
+[![Build Status](https://travis-ci.org/aninternetof/rovercode.svg)](https://travis-ci.org/aninternetof/rovercode)
 
 rovercode is easy-to-use package for controlling robots (rovers) that can sense and react to their environment. The Blockly editor makes it easy to program and run your bot straight from your browser. Just drag and drop your commands to drive motors, read values from a variety of supported sensors, and see what your rover sees with the built in webcam viewer.
 

--- a/README.md
+++ b/README.md
@@ -51,5 +51,7 @@ Then, still on your development PC, head to rovercode.org and connect to your "r
 ## Play and Contribute
 rovercode is usable now, but we have lots of great features left to be added. Check out the [contributing instructions](https://github.com/aninternetof/rovercode/wiki/Contributing) then head over to the [feature tracker](https://github.com/aninternetof/rovercode/projects/2) to see if there's something fun to contribute.
 
+## Run Tests
+
 ## License
 [GNU GPLv3](license) © Brady L. Hurlburt and the rovercode.org community

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![MailingList](https://img.shields.io/badge/join-mailing%20list-yellow.svg?style=flat)](http://rovercode.org/cgi-bin/mailman/listinfo/developers)
 [![](https://images.microbadger.com/badges/image/cabarnes/rovercode.svg)](https://microbadger.com/images/cabarnes/rovercode)
 [![Build Status](https://travis-ci.org/aninternetof/rovercode.svg)](https://travis-ci.org/aninternetof/rovercode)
+[![Coverage Status](https://coveralls.io/repos/github/aninternetof/rovercode/badge.svg)](https://coveralls.io/github/aninternetof/rovercode)
 
 rovercode is easy-to-use package for controlling robots (rovers) that can sense and react to their environment. The Blockly editor makes it easy to program and run your bot straight from your browser. Just drag and drop your commands to drive motors, read values from a variety of supported sensors, and see what your rover sees with the built in webcam viewer.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=config.settings.local
+addopts = --strict --cov=www --cov-report term-missing --cov-report html

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=config.settings.local
+norecursedirs = Adafruit_Python_GPIO
 addopts = --strict --cov=www --cov-report term-missing --cov-report html

--- a/setup.sh
+++ b/setup.sh
@@ -15,7 +15,7 @@ if [ ! -e ${ADAFRUIT_DIR} ]; then
 fi
 
 apt-get install -y python python-dev python-pip python-smbus nginx build-essential git libssl-dev
-pip install flask flask-socketio gevent uwsgi Sphinx==1.4.8 sphinx_rtd_theme
+pip install flask flask-socketio gevent uwsgi Sphinx==1.4.8 sphinx_rtd_theme pytest-flask pytest-cov mock
 
 pushd ${ADAFRUIT_DIR} > /dev/null
 python setup.py install

--- a/www/app.py
+++ b/www/app.py
@@ -8,13 +8,22 @@ import Adafruit_GPIO.GPIO as gpioLib
 
 # Let SocketIO choose the best async mode
 async_mode = 'gevent_uwsgi'
-app = Flask(__name__)
+
+def create_app():
+    app = Flask(__name__)
+    return app
+
+app = create_app()
+
+create_app()
 try:
     socketio = SocketIO(app, async_mode=async_mode)
 except:
     # Needed for sphinx documentation
     socketio = SocketIO(app)
 thread = None
+
+print "Registering rover!"
 
 pwm = pwmLib.get_platform_pwm(pwmtype="softpwm")
 gpio = gpioLib.get_platform_gpio();

--- a/www/conftest.py
+++ b/www/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from app import create_app
+
+@pytest.fixture
+def app():
+    app = create_app()
+    return app
+
+@pytest.fixture
+def will_fail():
+    assert False

--- a/www/tests/test_app.py
+++ b/www/tests/test_app.py
@@ -1,0 +1,4 @@
+import app
+
+def test_dummy():
+    assert len(app.binary_sensors) > 0


### PR DESCRIPTION
Adds pytest w/ Travis and coverage w/ Coveralls.

Known problem: Running the test in Docker produces no coverage output (I think similar to the problem we're seeing in rovercode-web). I made a note of the problem in the readme. If somebody wants to pull it down and take a whack at fixing it, please do! I've banged my head against it for long enough now, and [SO shows](http://stackoverflow.com/questions/18573542/coverage-py-does-not-cover-script-if-py-test-executes-it-from-another-directory) that lots of people have trouble getting coverage to find everything.